### PR TITLE
feat: update to bevy 0.18

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = ["assets/**", ".vscode/**"]
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-bevy = { version = "0.17", default-features = false, features = [
+bevy = { version = "0.18", default-features = false, features = [
     "bevy_render",
     "bevy_sprite",
     "bevy_window",
@@ -24,7 +24,7 @@ bevy = { version = "0.17", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-bevy = { version = "0.17" }
+bevy = { version = "0.18" }
 rand = "0.9"
 
 [[example]]

--- a/examples/scale_ui.rs
+++ b/examples/scale_ui.rs
@@ -36,6 +36,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             align_items: AlignItems::Center,
             justify_content: JustifyContent::Center,
             flex_direction: FlexDirection::Column,
+            border_radius: BorderRadius::MAX,
             row_gap: Val::Px(10.0),
             ..default()
         },
@@ -43,7 +44,6 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             (
                 base_button("Button 1"),
                 BorderColor::all(Color::BLACK),
-                BorderRadius::MAX,
                 BackgroundColor(Color::srgb(0.15, 0.15, 0.15)),
             ),
             (
@@ -52,10 +52,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     image: asset_server.load("button.png"),
                     image_mode: NodeImageMode::Sliced(TextureSlicer {
                         border: BorderRect {
-                            left: 4.0,
-                            right: 4.0,
-                            top: 4.0,
-                            bottom: 5.0
+                            min_inset: Vec2::splat(4.),
+                            max_inset: Vec2::new(4., 5.)
                         },
                         ..default()
                     }),

--- a/src/zoom.rs
+++ b/src/zoom.rs
@@ -1,6 +1,6 @@
 use bevy::{
     asset::{AssetEvent, AssetId},
-    camera::{Projection, Viewport},
+    camera::{Projection, RenderTarget, Viewport},
     ecs::{message::MessageReader, system::ResMut},
     log::debug,
     math::{UVec2, Vec2},
@@ -55,6 +55,7 @@ pub(crate) fn pixel_zoom_system(
     primary_window: Query<Entity, With<PrimaryWindow>>,
     mut cameras: Query<(
         &mut Camera,
+        &RenderTarget,
         &PixelZoom,
         Option<&PixelViewport>,
         Has<WithUiScaling>,
@@ -81,8 +82,10 @@ pub(crate) fn pixel_zoom_system(
         })
         .collect();
 
-    for (mut camera, pixel_zoom, pixel_viewport, with_ui_scaling, mut projection) in &mut cameras {
-        if let Some(normalized_target) = camera.target.normalize(primary_window) {
+    for (mut camera, target, pixel_zoom, pixel_viewport, with_ui_scaling, mut projection) in
+        &mut cameras
+    {
+        if let Some(normalized_target) = target.normalize(primary_window) {
             if normalized_target.is_changed(&changed_window_ids, &changed_image_handles)
                 || camera.is_added()
                 || projection.is_changed()


### PR DESCRIPTION
The changes that affected this crate were
- In `zoom.rs`
  - [`RenderTarget` is now a component](https://bevy.org/learn/migration-guides/0-17-to-0-18/#rendertarget-is-now-a-component)
- In the `scale_ui` example
  - [`BorderRect` now has `Vec2` fields](https://bevy.org/learn/migration-guides/0-17-to-0-18/#borderrect-now-has-vec2-fields)
  - [`BorderRadius` has been added to Node and is no longer a component`](https://bevy.org/learn/migration-guides/0-17-to-0-18/#borderradius-has-been-added-to-node-and-is-no-longer-a-component)